### PR TITLE
Make sure `kubedee_container_image` is valid hostname

### DIFF
--- a/lib.bash
+++ b/lib.bash
@@ -55,7 +55,7 @@ kubedee::exit_error() {
 }
 
 readonly kubedee_base_image="ubuntu:18.04"
-readonly kubedee_container_image="kubedee-container-image-${kubedee_version}"
+readonly kubedee_container_image="kubedee-container-image-${kubedee_version//[._]/-}"
 readonly kubedee_etcd_version="v3.3.13"
 readonly kubedee_runc_version="v1.0.0-rc8"
 readonly kubedee_cni_plugins_version="v0.7.5"


### PR DESCRIPTION
Avoid the following error:

```
$ kubedee up test --kubernetes-version v1.14.2
Creating network for test ...
Network kubedee-jiz7o8 created
Pruning old kubedee caches ...
Pruning old kubedee container images ...
Preparing kubedee container image ...
Creating kubedee-container-image-v0.1.0-setup
Error: Failed container creation: Create container: Container name isn't a valid hostname
```