### PR TITLE
Prefix kubedee messages with `==> `

### DIFF
--- a/kubedee
+++ b/kubedee
@@ -161,7 +161,7 @@ cmd_start() {
   if [[ "${create_user_sa}" == "true" ]]; then
     kubedee::create_user_service_account "${cluster_name}"
   fi
-  kubedee::log_success "\\nCluster ${cluster_name} started"
+  kubedee::log_success "Cluster ${cluster_name} started"
   if [[ "${no_set_context}" == "false" ]]; then
     kubedee::log_success "kubectl config current-context set to kubedee-${cluster_name}\\n"
   else

--- a/lib.bash
+++ b/lib.bash
@@ -8,22 +8,22 @@
 
 kubedee::log_info() {
   local -r message="${1:-""}"
-  echo -e "\\033[1;37m${message}\\033[0m"
+  echo -e "\\033[1;37m==> ${message}\\033[0m"
 }
 
 kubedee::log_success() {
   local -r message="${1:-""}"
-  echo -e "\\033[1;32m${message}\\033[0m"
+  echo -e "\\033[1;32m==> ${message}\\033[0m"
 }
 
 kubedee::log_warn() {
   local -r message="${1:-""}"
-  echo -e "\\033[1;33m${message}\\033[0m" >&2
+  echo -e "\\033[1;33m==> ${message}\\033[0m" >&2
 }
 
 kubedee::log_error() {
   local -r message="${1:-""}"
-  echo -e "\\033[1;31m${message}\\033[0m" >&2
+  echo -e "\\033[1;31m==> ${message}\\033[0m" >&2
 }
 
 kubedee::exit_error() {

--- a/lib.bash
+++ b/lib.bash
@@ -1484,7 +1484,7 @@ kubedee::smoke_test() {
       break
     else
       kubedee::log_info "${deployment_name} not ready yet"
-      sleep 3
+      sleep 5
     fi
   done
   kubedee::log_success "Successfully connected to ${deployment_name}"


### PR DESCRIPTION
Similar to other tools (e.g. Vagrant), prefix kubedee's messages with
`==> ` to differentiate them from messages of the called tools.