### PR TITLE
README: move "Certified Kubernetes" logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-<img alt="Certified Kubernetes logo" width="100px" align="right" src="https://raw.githubusercontent.com/cncf/artwork/master/projects/kubernetes/certified-kubernetes/versionless/pantone/certified-kubernetes-pantone.png">
-
 ![kubedee logo](docs/logo/kubedee.png)
 
 [![builds.sr.ht status](https://builds.sr.ht/~schu/kubedee.svg)](https://builds.sr.ht/~schu/kubedee?)
+
+<img alt="Certified Kubernetes logo" width="100px" align="right" src="https://raw.githubusercontent.com/cncf/artwork/master/projects/kubernetes/certified-kubernetes/versionless/pantone/certified-kubernetes-pantone.png">
 
 Fast multi-node Kubernetes (>= 1.12) development and test clusters on [LXD](https://github.com/lxc/lxd).
 


### PR DESCRIPTION
In the current position, alignment doesn't look right on mobile.