### PR TITLE
improve mounting of host loop devices

### DIFF
--- a/lib.bash
+++ b/lib.bash
@@ -1210,7 +1210,7 @@ kubedee::configure_worker() {
   # Mount the host loop devices into the container to allow the kubelet
   # to gather rootfs info when the host root is on a loop device
   # (e.g. `/dev/mapper/c--vg-root on /dev/loop1 type ext4 ...`)
-  for ldev in /dev/loop[0-9]; do
+  for ldev in  $(find /dev/ -maxdepth 1 -type b -regex '.*/loop[0-9]+'); do
     lxc config device add "${container_name}" "${ldev#/dev/}" unix-block source="${ldev}" path="${ldev}"
   done
 

--- a/lib.bash
+++ b/lib.bash
@@ -1210,9 +1210,11 @@ kubedee::configure_worker() {
   # Mount the host loop devices into the container to allow the kubelet
   # to gather rootfs info when the host root is on a loop device
   # (e.g. `/dev/mapper/c--vg-root on /dev/loop1 type ext4 ...`)
-  for ldev in  $(find /dev/ -maxdepth 1 -type b -regex '.*/loop[0-9]+'); do
+  shopt -s nullglob
+  for ldev in /dev/loop[0-9]*; do
     lxc config device add "${container_name}" "${ldev#/dev/}" unix-block source="${ldev}" path="${ldev}"
   done
+  shopt -u nullglob
 
   # Mount the host /dev/kmsg device into the container to allow
   # kubelet's OOM manager to do its job. Otherwise we encounter the


### PR DESCRIPTION
fixes two issues:

1. mounting loop devices on hosts with more than 10 devices
2. fix invalid bind mount for systems without any loop devices (glob itself would be returned)

fixes #26.