### PR TITLE
lib: make sure to bind mount all loop devices

### DIFF
--- a/lib.bash
+++ b/lib.bash
@@ -1210,9 +1210,11 @@ kubedee::configure_worker() {
   # Mount the host loop devices into the container to allow the kubelet
   # to gather rootfs info when the host root is on a loop device
   # (e.g. `/dev/mapper/c--vg-root on /dev/loop1 type ext4 ...`)
-  for ldev in /dev/loop[0-9]; do
+  shopt -s nullglob
+  for ldev in /dev/loop[0-9]*; do
     lxc config device add "${container_name}" "${ldev#/dev/}" unix-block source="${ldev}" path="${ldev}"
   done
+  shopt -u nullglob
 
   # Mount the host /dev/kmsg device into the container to allow
   # kubelet's OOM manager to do its job. Otherwise we encounter the


### PR DESCRIPTION
The glob pattern that we use currently only takes into account up to the
first ten loop devices. But users could have more loop devices and the
root device could be located on one of those. Fix the glob pattern to
make sure all loop devices are bind mounted.

Also, do set `nullglob` to make sure the pattern doesn't resolve to
itself if it doesn't match (if the user doesn't have any loop devices at
all).

Fixes #26