### PR TITLE
Update cfssl und use upstream binaries

### DIFF
--- a/.builds/dist-arch.yml
+++ b/.builds/dist-arch.yml
@@ -17,8 +17,8 @@ tasks:
       echo 65536 | sudo tee /sys/module/nf_conntrack/parameters/hashsize
       sudo snap install lxd
       sudo usermod -a -G lxd $(whoami)
-      curl -fsSL https://files.schu.io/pub/cfssl/cfssl-linux-amd64-1.3.2 -o /tmp/cfssl && sudo install -m 0755 /tmp/cfssl /usr/local/bin/
-      curl -fsSL https://files.schu.io/pub/cfssl/cfssljson-linux-amd64-1.3.2 -o /tmp/cfssljson && sudo install -m 0755 /tmp/cfssljson /usr/local/bin/
+      curl -fsSL https://github.com/cloudflare/cfssl/releases/download/v1.4.1/cfssl_1.4.1_linux_amd64 -o /tmp/cfssl && sudo install -m 0755 /tmp/cfssl /usr/local/bin/
+      curl -fsSL https://github.com/cloudflare/cfssl/releases/download/v1.4.1/cfssljson_1.4.1_linux_amd64 -o /tmp/cfssljson && sudo install -m 0755 /tmp/cfssljson /usr/local/bin/
       curl -fsSL https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl -o /tmp/kubectl && sudo install -m 0755 /tmp/kubectl /usr/local/bin/
   - setup: |
       export PATH=/var/lib/snapd/snap/bin:$PATH

--- a/.builds/dist-ubuntu.yml
+++ b/.builds/dist-ubuntu.yml
@@ -14,8 +14,8 @@ tasks:
   - setup: |
       export PATH=/snap/bin:$PATH
       lxd init --auto --storage-backend btrfs
-      curl -fsSL https://files.schu.io/pub/cfssl/cfssl-linux-amd64-1.3.2 -o /tmp/cfssl && sudo install -m 0755 /tmp/cfssl /usr/local/bin/
-      curl -fsSL https://files.schu.io/pub/cfssl/cfssljson-linux-amd64-1.3.2 -o /tmp/cfssljson && sudo install -m 0755 /tmp/cfssljson /usr/local/bin/
+      curl -fsSL https://github.com/cloudflare/cfssl/releases/download/v1.4.1/cfssl_1.4.1_linux_amd64 -o /tmp/cfssl && sudo install -m 0755 /tmp/cfssl /usr/local/bin/
+      curl -fsSL https://github.com/cloudflare/cfssl/releases/download/v1.4.1/cfssljson_1.4.1_linux_amd64 -o /tmp/cfssljson && sudo install -m 0755 /tmp/cfssljson /usr/local/bin/
       curl -fsSL https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl -o /tmp/kubectl && sudo install -m 0755 /tmp/kubectl /usr/local/bin/
   - test: |
       export PATH=/snap/bin:$PATH

--- a/contrib/terraform/hetzner-cloud/user-data.bash
+++ b/contrib/terraform/hetzner-cloud/user-data.bash
@@ -19,9 +19,9 @@ lxd init --auto --storage-backend btrfs
 
 usermod -a -G lxd,sudo ubuntu
 
-curl -fsSL https://files.schu.io/pub/cfssl/cfssl-linux-amd64-1.3.2 -o /tmp/cfssl &&
+curl -fsSL https://github.com/cloudflare/cfssl/releases/download/v1.4.1/cfssl_1.4.1_linux_amd64 -o /tmp/cfssl &&
   install -m 0755 /tmp/cfssl /usr/local/bin/
-curl -fsSL https://files.schu.io/pub/cfssl/cfssljson-linux-amd64-1.3.2 -o /tmp/cfssljson &&
+curl -fsSL https://github.com/cloudflare/cfssl/releases/download/v1.4.1/cfssl_1.4.1_linux_amd64 -o /tmp/cfssljson &&
   install -m 0755 /tmp/cfssljson /usr/local/bin/
 
 readonly k8s_latest="$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)"


### PR DESCRIPTION
cfssl didn't regularly provide builds in the past but does now, thus
switch to the official binaries from upstream.