### PR TITLE
Updates relating to k8s-1.19 stable release

### DIFF
--- a/lib.bash
+++ b/lib.bash
@@ -1107,7 +1107,7 @@ kubedee::configure_rbac() {
   until kubectl --kubeconfig "${kubeconfig}" get clusterroles &>/dev/null; do sleep 1; done
 
   cat <<APISERVER_RBAC | kubectl --kubeconfig "${kubeconfig}" apply -f -
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   annotations:
@@ -1129,7 +1129,7 @@ rules:
 APISERVER_RBAC
 
   cat <<APISERVER_BINDING | kubectl --kubeconfig "${kubeconfig}" apply -f -
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: system:kube-apiserver

--- a/manifests/ingress-nginx.yml
+++ b/manifests/ingress-nginx.yml
@@ -102,7 +102,7 @@ metadata:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: nginx-ingress-clusterrole
@@ -215,7 +215,7 @@ subjects:
 
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: privileged-psp-nisa-binding
@@ -229,7 +229,7 @@ subjects:
     namespace: ingress-nginx
 ---
 
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: nginx-ingress-clusterrole-nisa-binding

--- a/manifests/kube-flannel.yml
+++ b/manifests/kube-flannel.yml
@@ -47,7 +47,7 @@ spec:
     rule: 'RunAsAny'
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flannel
 rules:
@@ -76,7 +76,7 @@ rules:
       - patch
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flannel
 roleRef:

--- a/scripts/smoke-test
+++ b/scripts/smoke-test
@@ -26,7 +26,7 @@ trap cleanup EXIT
 if [[ $# -gt 0 ]]; then
   readonly k8s_versions=("$@")
 else
-  readonly k8s_versions=("v1.17.9" "v1.18.6" "v1.19.0-rc.3")
+  readonly k8s_versions=("v1.17.12" "v1.18.9" "v1.19.2")
 fi
 
 readonly kubedee_dir="${tmp_dir}/kubedee"


### PR DESCRIPTION
Just a couple of minor changes to silence deprecation warnings from Kubernetes 1.19 and to update tests to currently maintained versions.