### PR TITLE
Updates relating to k8s-1.20 stable release

### DIFF
--- a/manifests/kube-flannel.yml
+++ b/manifests/kube-flannel.yml
@@ -169,7 +169,7 @@ spec:
       serviceAccountName: flannel
       initContainers:
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.12.0-amd64
+        image: quay.io/coreos/flannel:v0.13.0-amd64
         command:
         - cp
         args:
@@ -183,7 +183,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.12.0-amd64
+        image: quay.io/coreos/flannel:v0.13.0-amd64
         command:
         - /opt/bin/flanneld
         args:

--- a/scripts/smoke-test
+++ b/scripts/smoke-test
@@ -26,7 +26,7 @@ trap cleanup EXIT
 if [[ $# -gt 0 ]]; then
   readonly k8s_versions=("$@")
 else
-  readonly k8s_versions=("v1.17.12" "v1.18.9" "v1.19.2")
+  readonly k8s_versions=("v1.17.15" "v1.18.13" "v1.19.5" "v1.20.0")
 fi
 
 readonly kubedee_dir="${tmp_dir}/kubedee"


### PR DESCRIPTION
This update primarily reworks how the API server check works, as it doesn't expose an unauthenticated plaintext port 8080 on the controller's localhost.

Also fixes conntrack issues as a side effect and closes #60, fixing #59 since `TokenRequest` is now generally available, requiring related configuration options on API server execution.