### PR TITLE
manifests/core-dns: update 1.6.6 → 1.8.0

### DIFF
--- a/manifests/core-dns.yml
+++ b/manifests/core-dns.yml
@@ -27,6 +27,13 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -57,7 +64,6 @@ data:
         health
         kubernetes cluster.local in-addr.arpa ip6.arpa {
           pods insecure
-          upstream
           fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
@@ -99,7 +105,7 @@ spec:
         beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: coredns/coredns:1.6.6
+        image: coredns/coredns:1.8.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:


### PR DESCRIPTION
Considering I've bumped into some slight name resolution issues by running development releases of CoreDNS, here's a version bump with accompanying new permissions it will end up complaining about.