### PR TITLE
lib: added Kata Containers v2 runtime

### DIFF
--- a/kubedee
+++ b/kubedee
@@ -94,6 +94,7 @@ cmd_create() {
   kubedee::copy_crio_files "${cluster_name}"
   kubedee::copy_runc_binaries "${cluster_name}"
   kubedee::copy_cni_plugins "${cluster_name}"
+  kubedee::copy_kata_artifacts "${cluster_name}"
   kubedee::create_certificate_authority_etcd "${cluster_name}"
   kubedee::create_certificate_authority_k8s "${cluster_name}"
   kubedee::create_certificate_authority_aggregation "${cluster_name}"
@@ -143,6 +144,7 @@ cmd_start() {
   fi
   kubedee::deploy_flannel "${cluster_name}"
   kubedee::deploy_core_dns "${cluster_name}"
+  kubedee::deploy_kata_runtimes "${cluster_name}"
   kubedee::wait_for_node "${cluster_name}" "kubedee-${cluster_name}-controller"
   kubedee::label_and_taint_controller "${cluster_name}" "kubedee-${cluster_name}-controller"
   for ((i = 0; i < num_worker; i++)); do

--- a/manifests/kata-runtime-classes.yml
+++ b/manifests/kata-runtime-classes.yml
@@ -1,0 +1,24 @@
+---
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: runc
+handler: runc
+---
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: kata-qemu
+handler: kata-qemu
+---
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: kata-fc
+handler: kata-fc
+---
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: kata-clh
+handler: kata-clh


### PR DESCRIPTION
Since I've already done the legwork in my personal fork, I figured upstreaming Kata support would be a natural next step. Not sure if SourceHut exposes KVM to it's test job runs, so I've held back on those for now.

[Kata-Containers](https://katacontainers.io/) is a runtime leveraging KVM through different VMMs (at the time of writing, QEMU, [Firecracker](https://firecracker-microvm.github.io/) and [Cloud-Hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor) support is maintained upstream) to spawn lightweight virtual machines with a minimal kernel to isolate untrusted workloads on a Kubernetes node.

There's also an option of [enabling VM caching](https://github.com/kata-containers/documentation/blob/master/how-to/what-is-vm-cache-and-how-do-I-use-it.md) to speed up launch times, but it would require even more `sed`ding than necessary to run, which I don't feel particularly comfortable about introducing these in the first place, so since CRI-O config files aren't in-repo, I improvised a bit.